### PR TITLE
Make user bubble and chat bubble styles apply independently.

### DIFF
--- a/src/ChatBubble/index.tsx
+++ b/src/ChatBubble/index.tsx
@@ -36,8 +36,8 @@ export default class ChatBubble extends React.Component {
             ...bubblesCentered
               ? {}
               : styles.recipientChatbubbleOrientationNormal,
-            ...chatbubble,
             ...userBubble,
+            ...chatbubble,
           };
 
     return (


### PR DESCRIPTION
Currently, when I use 'bubbleStyles', the useBubble style is getting
applied to both userBubble and chatbubble. This commit fixes this
issue and applies the right styles to the right bubbles.